### PR TITLE
iOS: Track user id.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Manifests/ios.json
+++ b/Manifests/ios.json
@@ -9,18 +9,18 @@
   "dependency_repository_url": [
     "git@github.com:applicaster/zapp-analytics-plugin-firebase.git"
   ],
-  "author_name": "Roman Karpievich",
-  "author_email": "r.karpievich@applicaster.com",
-  "manifest_version": "8.1.0",
+  "author_name": "Pablo Rueda",
+  "author_email": "p.rueda@applicaster.com",
+  "manifest_version": "8.2.0",
   "name": "Google Analytics for Firebase",
-  "description": "Google's free, deep, and broadly integrated analytics system designed specifically for mobile.",
+  "description": "Google's free, deep, and broadly integrated analytics system designed specifically for mobile. Please do not populate the user id field unless your app is legally authorised (for further information, please reach support).",
   "identifier": "firebase_ios",
   "type": "analytics",
   "platform": "ios",
   "ui_builder_support": true,
   "min_zapp_sdk": "13.0.0-Dev",
   "dependency_name": "ZappAnalyticsPluginFirebase",
-  "dependency_version": "8.1.0",
+  "dependency_version": "8.2.0",
   "whitelisted_account_ids": [],
   "react_native": false,
   "cover_image": "https://res.cloudinary.com/dtiodujtz/image/upload/v1553522185/Plugins/GAforFirebase.jpg",
@@ -31,6 +31,12 @@
       "label": "Send User Data",
       "default": 1,
       "tooltip_text": "Sends any user data collected in the app. Per Google&apos;s policies, we will not send any user data identified as PII (Personally Identifiable Information)."
+    },
+    {
+      "type": "text",
+      "key": "user_id",
+      "label": "User ID",
+      "tooltip_text": "Please do not populate the user id field unless your app is legally authorised (for further information, please reach support)."
     }
   ],
   "targets": [

--- a/Specs/ZappAnalyticsPluginFirebase/8.2.0/ZappAnalyticsPluginFirebase.podspec
+++ b/Specs/ZappAnalyticsPluginFirebase/8.2.0/ZappAnalyticsPluginFirebase.podspec
@@ -1,29 +1,30 @@
 Pod::Spec.new do |s|
-  s.name  = "__framework_name__"
-  s.version = '__version__'
-  s.platform  = :ios, '__ios_platform_version__'
-  s.summary = "__framework_name__"
-  s.description = "__framework_name__ container."
-  s.homepage  = "https://github.com/applicaster/__framework_name__-iOS"
+  s.name  = "ZappAnalyticsPluginFirebase"
+  s.version = '8.2.0'
+  s.platform  = :ios, '10.0'
+  s.summary = "ZappAnalyticsPluginFirebase"
+  s.description = "ZappAnalyticsPluginFirebase container."
+  s.homepage  = "https://github.com/applicaster/zapp-analytics-plugin-firebase"
   s.license = 'CMPS'
   s.author = { "cmps" => "Applicaster LTD." }
-  s.source  = { :git => "git@github.com:applicaster/__framework_name__-iOS.git", :tag => s.version.to_s }
+  s.source  = { :git => "git@github.com:applicaster/zapp-analytics-plugin-firebase.git", :tag => s.version.to_s }
   s.requires_arc = true
   s.static_framework = true
 
   s.public_header_files = '**/*.h'
-  s.source_files = '__framework_name__/**/*.{h,m,swift}', '"${PODS_ROOT}"/Firebase/**/*.{h}'
+  s.source_files = 'iOS/ZappAnalyticsPluginFirebase/**/*.{h,m,swift}', '"${PODS_ROOT}"/Firebase/**/*.{h}'
 
   s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
                           'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}"/Firebase/**',
                           'OTHER_LDFLAGS' => '$(inherited) -objc -framework "FirebaseCore" -framework "FirebaseInstanceID" -framework "FirebaseAnalytics"',
                           'ENABLE_BITCODE' => 'YES',
-                          'SWIFT_VERSION' => '__swift_version__',
+                          'SWIFT_VERSION' => '5.1',
                           'USER_HEADER_SEARCH_PATHS' => '"$(inherited)" "${PODS_ROOT}"/Firebase/**'
               }
 
   s.dependency 'ZappAnalyticsPluginsSDK'
   s.dependency 'Firebase'
   s.dependency 'Firebase/Analytics'
+  s.dependency 'FirebaseInstanceID'
   s.dependency 'ZappPlugins'
 end

--- a/iOS/.gitignore
+++ b/iOS/.gitignore
@@ -1,0 +1,69 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+docs/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -11,6 +11,7 @@ target 'ZappAnalyticsPluginFirebase' do
   # Pods for ZappAnalyticsPluginChartbeat
   pod 'ZappAnalyticsPluginsSDK'
   pod 'Firebase', '= 5.18.0'
+  pod 'ZappPlugins'
 
   target 'ZappAnalyticsPluginFirebaseTests' do
     # Pods for testing

--- a/iOS/Podfile.lock
+++ b/iOS/Podfile.lock
@@ -45,25 +45,28 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (5.8.0):
     - GoogleUtilities/Logger
-  - nanopb (0.3.901):
-    - nanopb/decode (= 0.3.901)
-    - nanopb/encode (= 0.3.901)
-  - nanopb/decode (0.3.901)
-  - nanopb/encode (0.3.901)
-  - ZappAnalyticsPluginsSDK (8.0.4):
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
+  - ZappAnalyticsPluginsSDK (11.0.0):
     - ZappPlugins
-  - ZappPlugins (9.1.8)
+  - ZappCore (0.9.18)
+  - ZappPlugins (11.8.0):
+    - ZappCore
 
 DEPENDENCIES:
   - Firebase (= 5.18.0)
   - ZappAnalyticsPluginsSDK
+  - ZappPlugins
 
 SPEC REPOS:
-  "git@github.com:applicaster/CocoaPods-Private.git":
-    - ZappAnalyticsPluginsSDK
   "git@github.com:applicaster/CocoaPods.git":
+    - ZappAnalyticsPluginsSDK
+    - ZappCore
     - ZappPlugins
-  https://github.com/cocoapods/specs.git:
+  https://cdn.cocoapods.org/:
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
@@ -79,10 +82,11 @@ SPEC CHECKSUMS:
   FirebaseInstanceID: a122b0c258720cf250551bb2bedf48c699f80d90
   GoogleAppMeasurement: 6cf307834da065863f9faf4c0de0a936d81dd832
   GoogleUtilities: 04fce34bcd5620c1ee76fb79172105c74a4df335
-  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
-  ZappAnalyticsPluginsSDK: 6f8edcddc12ae4001098a3fa6fe87e6fe1a013bd
-  ZappPlugins: 19d19d6fe70d39a4fc5a323e6a9146e0ab629970
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
+  ZappAnalyticsPluginsSDK: 0b33b53031e6c1a3c32b4ff25fb63d6e78d8380f
+  ZappCore: cc45ec2514e5cf879593a58e60b1815a7abe0048
+  ZappPlugins: c989f6ebf539f0071032d064e225349f420950e5
 
-PODFILE CHECKSUM: e4232d72d4474ea7e36db263c02b37e9517c9bc0
+PODFILE CHECKSUM: dc1fee152a85f0bfdd06a3626d281f1e6024e1a8
 
 COCOAPODS: 1.7.5

--- a/iOS/Podspec-templates/ZappAnalyticsPluginFirebase-template-public.podspec
+++ b/iOS/Podspec-templates/ZappAnalyticsPluginFirebase-template-public.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
 
   # base dependency
   s.dependency 'ZappAnalyticsPluginsSDK'
+  s.dependency 'ZappPlugins'
 
   # config
   s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',

--- a/iOS/ZappAnalyticsPluginFirebase.podspec
+++ b/iOS/ZappAnalyticsPluginFirebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ZappAnalyticsPluginFirebase"
-  s.version = '8.0.1'
+  s.version = '8.2.0'
   s.summary          = "ZappAnalyticsPluginFirebase"
   s.description      = <<-DESC
                         ZappAnalyticsPluginFirebase container.
@@ -28,4 +28,5 @@ Pod::Spec.new do |s|
   s.dependency 'ZappAnalyticsPluginsSDK'
   s.dependency 'Firebase', '= 5.18.0'
   s.dependency 'Firebase/Analytics'
+  s.dependency 'ZappPlugins'
 end

--- a/iOS/ZappAnalyticsPluginFirebase.xcodeproj/project.pbxproj
+++ b/iOS/ZappAnalyticsPluginFirebase.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 8.1.0;
+				MARKETING_VERSION = 8.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.applicaster.ZappAnalyticsPluginFirebase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -504,7 +504,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 8.1.0;
+				MARKETING_VERSION = 8.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.applicaster.ZappAnalyticsPluginFirebase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOS/ZappAnalyticsPluginFirebase/APAnalyticsProviderFirebase.swift
+++ b/iOS/ZappAnalyticsPluginFirebase/APAnalyticsProviderFirebase.swift
@@ -142,13 +142,20 @@ open class APAnalyticsProviderFirebase: ZPAnalyticsProvider {
                 Analytics.setUserProperty(value, forName: key)
             }
             
-            //We want to add the user id only if it is configured as allow-tracking-user-id-for-app-family-<APP_FAMILY_ID> in the plugin configurations
-            if let userIDParameter = configurationJSON?[UserIDConstants.userIDJSONConfig] as? String,
-                let familyID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.familyIDLocalStorageKey, namespace:nil),
-                userIDParameter == "\(UserIDConstants.userIDCompareString)\(familyID)" {
-                let userID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.userIDLocalStorageKey, namespace:UserIDConstants.loginNamespace)
-                Analytics.setUserID(userID)
-            }
+            checkUserID()
+        }
+    }
+
+    //Method that add the user id only if it is configured as allow-tracking-user-id-for-app-family-<APP_FAMILY_ID> in the plugin configurations
+    fileprivate func checkUserID() {
+        guard let userIDParameter = configurationJSON?[UserIDConstants.userIDJSONConfig] as? String,
+            let familyID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.familyIDLocalStorageKey, namespace:nil),
+            let userID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.userIDLocalStorageKey, namespace:UserIDConstants.loginNamespace) else {
+                return
+        }
+
+        if (userIDParameter == "\(UserIDConstants.userIDCompareString)\(familyID)") {
+            Analytics.setUserID(userID)
         }
     }
     

--- a/iOS/ZappAnalyticsPluginFirebase/APAnalyticsProviderFirebase.swift
+++ b/iOS/ZappAnalyticsPluginFirebase/APAnalyticsProviderFirebase.swift
@@ -12,6 +12,7 @@
 
 import Firebase
 import ZappAnalyticsPluginsSDK
+import ZappPlugins
 
 open class APAnalyticsProviderFirebase: ZPAnalyticsProvider {
         
@@ -34,6 +35,15 @@ open class APAnalyticsProviderFirebase: ZPAnalyticsProvider {
     //Json Keys
     struct JsonKeys {
         static let sendUserData = "Send_User_Data"
+    }
+    
+    //Constants used for User ID tracking functionality
+    struct UserIDConstants {
+        static let userIDJSONConfig = "user_id"
+        static let familyIDLocalStorageKey = "app_family_id"
+        static let userIDCompareString = "allow-tracking-user-id-for-app-family-"
+        static let userIDLocalStorageKey = "user_id"
+        static let loginNamespace = "login"
     }
     
     override open func getKey() -> String {
@@ -130,6 +140,14 @@ open class APAnalyticsProviderFirebase: ZPAnalyticsProvider {
                     continue
                 }
                 Analytics.setUserProperty(value, forName: key)
+            }
+            
+            //We want to add the user id only if it is configured as allow-tracking-user-id-for-app-family-<APP_FAMILY_ID> in the plugin configurations
+            if let userIDParameter = configurationJSON?[UserIDConstants.userIDJSONConfig] as? String,
+                let familyID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.familyIDLocalStorageKey, namespace:nil),
+                userIDParameter == "\(UserIDConstants.userIDCompareString)\(familyID)" {
+                let userID = ZAAppConnector.sharedInstance().storageDelegate?.localStorageValue(for:UserIDConstants.userIDLocalStorageKey, namespace:UserIDConstants.loginNamespace)
+                Analytics.setUserID(userID)
             }
         }
     }


### PR DESCRIPTION
## Description
In conversations between Udi, Gavri and Aviran, has been aproved that implementation team creates a PR for a new functionality to the google analytic plugin.

This new functionality is the ability to the analytics plugin to track the user_id: https://firebase.google.com/docs/analytics/userid

We want this functionality to be public available for all apps, but difficult to configure, as we don't want people to configure if they don't know what they are doing. For that reason it should only be enable if a new parameter in plugin configurations named called user_id has the value should allow-tracking-user-id-for-app-family-<APP_FAMILY_ID>

The identifier for the user_id will be setup in those login plugins that desire to implement this, under the local storage, with key "user_id" under the "login" namespace.

https://applicaster.atlassian.net/browse/IM-501

## Known issues

## Checklist

* [x] PR is scoped to one task
* [x] Tests are included
* [x] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
The only way to test this is end to end, you need access to TVA Firebase console. You should check that analytics are being tracked using the user id, for that just launch the app and login. After login you should see that your tracking contain the user id.
* specific apps / plugins to test :
Television Academy