### PR TITLE
Avoid react-native classes duplication errors while building with new SDK

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -56,7 +56,9 @@ dependencies {
     if (devSDK != null) {
         implementation project(':applicaster-android-sdk')
     } else {
-        api 'com.applicaster:applicaster-android-sdk-core:6.1.0'
+        api ('com.applicaster:applicaster-android-sdk:6.1.0') {
+            exclude group:    'com.applicaster', module: 'react-native'
+        }
 
         testImplementation 'junit:junit:4.12'
         testImplementation 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
## Description
Added an exclude statement when adding the applicaster SDK as a dependency for Firebase

## Checklist

* [X] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [X] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included