### PR TITLE
Register to an event for using sendUserProperties on time

### DIFF
--- a/Android/src/main/java/applicaster/analytics/firebase/FirebaseAgent.java
+++ b/Android/src/main/java/applicaster/analytics/firebase/FirebaseAgent.java
@@ -1,8 +1,13 @@
 package applicaster.analytics.firebase;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.SystemClock;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.applicaster.analytics.BaseAnalyticsAgent;
 import com.applicaster.app.APProperties;
@@ -40,6 +45,8 @@ public class FirebaseAgent extends BaseAnalyticsAgent {
     public static final String GA_PREFIX = "ga_";
     public static final String SEND_USER_DATA = "Send_User_Data";
     public static final String USER_ID = "user_id";
+    public static final String SEND_BROADCAST_ACTION = "send_broadcast_from_rn";
+    public static final String EVENT_PROPERTIES = "event_properties";
     private static final String TAG = FirebaseAgent.class.getSimpleName();
     private Map<Character,String> legend;
 
@@ -68,6 +75,18 @@ public class FirebaseAgent extends BaseAnalyticsAgent {
         // Obtain the FirebaseAnalytics instance.
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
         legend = getLegend(context);
+
+        // Catch the send_broadcast_from_rn action sent from the RN Broadcast Manager and call sendUserProperties
+        LocalBroadcastManager.getInstance(context).registerReceiver(new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                try {
+                    sendUserProperties(new JSONObject(intent.getStringExtra(EVENT_PROPERTIES)));
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+            }
+        }, new IntentFilter(SEND_BROADCAST_ACTION));
     }
 
     @Override

--- a/Android/src/main/java/applicaster/analytics/firebase/FirebaseAgent.java
+++ b/Android/src/main/java/applicaster/analytics/firebase/FirebaseAgent.java
@@ -47,6 +47,7 @@ public class FirebaseAgent extends BaseAnalyticsAgent {
     public static final String USER_ID = "user_id";
     public static final String SEND_BROADCAST_ACTION = "send_broadcast_from_rn";
     public static final String EVENT_PROPERTIES = "event_properties";
+    public static final String EVENT_NAME = "event_name";
     private static final String TAG = FirebaseAgent.class.getSimpleName();
     private Map<Character,String> legend;
 
@@ -81,7 +82,9 @@ public class FirebaseAgent extends BaseAnalyticsAgent {
             @Override
             public void onReceive(Context context, Intent intent) {
                 try {
-                    sendUserProperties(new JSONObject(intent.getStringExtra(EVENT_PROPERTIES)));
+                    if ("userProperties".equals(intent.getStringExtra(EVENT_NAME))) {
+                        sendUserProperties(new JSONObject(intent.getStringExtra(EVENT_PROPERTIES)));
+                    }
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
## Description
Use the LocalBroadcastManager to register for an event that will be sent from the login plugin and upon receiving, we will know we can call the sendUserProperties method

## Checklist

* [ ] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [X] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included
